### PR TITLE
Add --recursive=y to pylint call

### DIFF
--- a/nox-utils/src/tmlt/nox_utils/_session_manager.py
+++ b/nox-utils/src/tmlt/nox_utils/_session_manager.py
@@ -251,7 +251,7 @@ class SessionManager:
         @install_group("pylint")
         def pylint(sess: Session) -> None:
             """Run pylint."""
-            sess.run("pylint", "--score=no", *self._code_dirs)
+            sess.run("pylint", "--score=no", "--recursive=y", *self._code_dirs)
 
     def pydocstyle(self) -> None:
         @session(name="pydocstyle", tags=["lint"], python=self._default_python_version)


### PR DESCRIPTION
With the new nox-utils, we're pointing pylint at the directory containing the package (`pylint src`), rather than the package itself (`pylint src/tmlt`). For analytics, this seems to cause pylint to find a bunch of spurious cyclic import errors. Running `pylint src/tmlt` works too, but this seemed like a simpler fix. See also https://pylint.readthedocs.io/en/stable/user_guide/usage/run.html#on-module-packages-or-directories