### PR TITLE
Add nox session for creating release commits

### DIFF
--- a/nox-utils/noxfile.py
+++ b/nox-utils/noxfile.py
@@ -4,10 +4,12 @@ from tmlt.nox_utils import SessionManager
 
 PACKAGE_NAME = "tmlt.nox_utils"
 """Name of the package."""
+PACKAGE_GITHUB = "opendp/tumult-tools"
+"""GitHub organization/project."""
 CWD = Path(".").resolve()
 
 sm = SessionManager(
-    PACKAGE_NAME, CWD,
+    PACKAGE_NAME, PACKAGE_GITHUB, CWD
 )
 sm.black()
 sm.isort()

--- a/nox-utils/pyproject.toml
+++ b/nox-utils/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.9,<4"
 dependencies = [
     "nox >=2022.8.7",
     "uv-dynamic-versioning >=0.8.2,<0.9",
+    "GitPython >=3.1.44,<4",
 ]
 
 [tool.uv]

--- a/nox-utils/src/tmlt/nox_utils/_release.py
+++ b/nox-utils/src/tmlt/nox_utils/_release.py
@@ -1,0 +1,190 @@
+"""Tools for creating releases."""
+
+import datetime
+import re
+import textwrap
+from pathlib import Path
+
+from git import Repo
+from git.refs.remote import RemoteReference
+from git.refs.tag import Tag
+from git.remote import Remote
+from nox import Session
+
+
+def push_release_commits(
+    sess: Session, directory: Path, package_github: str, version: str
+) -> None:
+    """Create and push a release branch/tag for the current commit."""
+    version_match = re.fullmatch(
+        (
+            r"(?P<base>(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*))"
+            r"(?P<prerelease>-(dev|alpha|beta|rc)\.(0|[1-9][0-9]*))?"
+        ),
+        version,
+    )
+    if version_match is None:
+        sess.error(
+            "Provided version number does not match expected semantic version format. "
+            "Versions should look like e.g. 0.1.2 or 1.2.1-alpha.2 -- other acceptable "
+            "pre-release types are dev, beta, and rc."
+        )
+
+    is_prerelease = version_match.group("prerelease") is not None
+
+    repo = Repo(directory)
+    origin = Remote(repo, "origin")
+    current_branch = repo.head.reference
+
+    if repo.is_dirty():
+        sess.error(
+            "Git repo is dirty, stash or commit your changes before making a release"
+        )
+    if repo.untracked_files:
+        sess.error(
+            "Git repo contains untracked files, stash or commit your changes before "
+            "making a release"
+        )
+
+    if current_branch.path != "refs/heads/main" and not is_prerelease:
+        sess.error("Releases may only be made from the main branch")
+
+    if not origin.exists():
+        sess.error("No remote 'origin' exists, unsure where to push changes")
+
+    sess.debug("Fetching latest state from origin...")
+    repo.git.fetch("origin", "--tags")
+
+    if RemoteReference(repo, f"refs/remotes/origin/release/{version}") in origin.refs:
+        sess.error(f"Branch release/{version} already exists")
+    if Tag(repo, f"refs/tags/{version}") in Tag.list_items(repo):
+        sess.error(f"Release tag {version} already exists")
+
+    if not is_prerelease:
+        sess.debug('Updating changelog "Unreleased" header...')
+        try:
+            _update_changelog_unreleased(version)
+        except RuntimeError as e:
+            sess.error(str(e))
+    else:
+        sess.debug("This is a prerelease, skipping changelog update")
+
+    sess.debug("Creating release branch...")
+    release_branch = repo.create_head(f"release/{version}")
+    repo.head.reference = release_branch  # type: ignore[misc]
+    sess.debug("Creating release commit...")
+    repo.index.add(["CHANGELOG.rst"])
+    repo.index.commit(f"[auto] Release {version}")
+    sess.debug("Creating release tag...")
+    release_tag = repo.create_tag(version)
+
+    if not is_prerelease:
+        _add_changelog_unreleased()
+
+    sess.debug("Creating post-release commit...")
+    repo.index.add(["CHANGELOG.rst"])
+    repo.index.commit(f"[auto] Post-release {version}")
+
+    sess.debug("Pushing release tag and branch...")
+    origin.push(release_branch)
+    origin.push(release_tag)
+
+    sess.debug("Switching back to original branch...")
+    repo.head.reference = current_branch  # type: ignore[misc]
+    repo.head.reset(index=True, working_tree=True)
+
+    sess.debug(
+        "Release push completed, tag is at: "
+        f"https://github.com/{package_github}/releases/tag/{release_tag}"
+    )
+
+    sess.debug(
+        "For non-dev releases, please merge release branch to main by creating a PR "
+        "(even if there are no changes):"
+    )
+    sess.debug(f"https://github.com/{package_github}/compare/{release_branch}?expand=1")
+
+
+def _update_changelog_unreleased(version: str) -> None:
+    """Replace the "Unreleased" changelog header with one for the given version.
+
+    Also adds an anchor for the version number so we can reference it elsewhere.
+    The automatic anchor for the header doesn't work because Sphinx doesn't
+    support anchors that start with digits.
+    """
+    with Path("CHANGELOG.rst").open("r", encoding="utf-8") as fp:
+        changelog_content = fp.readlines()
+    for i, line_content in enumerate(changelog_content):
+        if re.match("^Unreleased$", line_content):
+            if (
+                len(changelog_content) <= i + 1
+                or changelog_content[i + 1] != "----------\n"
+            ):
+                raise RuntimeError(
+                    "Renaming unreleased section in changelog failed, section header "
+                    "appears to be malformed"
+                )
+
+            # BEFORE
+            # Unreleased
+            # ----------
+
+            # AFTER
+            # .. _v1.2.3:
+            #
+            # 1.2.3 - 2020-01-01
+            # ------------------
+            version_header_title = f"{version} - {datetime.date.today()}"
+            version_header = textwrap.dedent(
+                f"""
+                .. _v{version}:
+
+                {version_header_title}
+                {'-' * len(version_header_title)}
+                """
+            )
+
+            changelog_content = (
+                changelog_content[:i]
+                + version_header.splitlines(keepends=True)
+                + changelog_content[i + 2 :]
+            )
+            break
+    else:
+        raise RuntimeError(
+            "Renaming unreleased section in changelog failed, "
+            "unable to find matching line"
+        )
+    with Path("CHANGELOG.rst").open("w", encoding="utf-8") as fp:
+        fp.writelines(changelog_content)
+
+
+def _add_changelog_unreleased() -> None:
+    """Add a new "Unreleased" section above the most recent release section."""
+    unreleased_header = ["Unreleased\n", "----------\n", "\n"]
+
+    anchor_regex = (
+        r"^\.\. _v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+        r"(-(alpha|beta|rc)\.(0|[1-9]\d*))?:$"
+    )
+
+    with Path("CHANGELOG.rst").open("r", encoding="utf-8") as fp:
+        changelog_content = fp.readlines()
+        for i, line_content in enumerate(changelog_content):
+            # If there's already an unreleased header, something has gone wrong.
+            if line_content == unreleased_header[0]:
+                raise RuntimeError(
+                    f"Changelog already contains an unreleased section on line {i+1}"
+                )
+            if re.match(anchor_regex, line_content):
+                for new_line in reversed(unreleased_header):
+                    changelog_content.insert(i, new_line)
+                break
+        else:
+            raise RuntimeError(
+                "Adding unreleased section in changelog failed, "
+                "unable to find release section to place it before"
+            )
+
+        with Path("CHANGELOG.rst").open("w", encoding="utf-8") as fp:
+            fp.writelines(changelog_content)

--- a/nox-utils/uv.lock
+++ b/nox-utils/uv.lock
@@ -201,6 +201,30 @@ wheels = [
 ]
 
 [[package]]
+name = "gitdb"
+version = "4.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.44"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/89/37df0b71473153574a5cdef8f242de422a0f5d26d7a9e231e6f169b4ad14/gitpython-3.1.44.tar.gz", hash = "sha256:c87e30b26253bf5418b01b0660f818967f3c503193838337fe5e573331249269", size = 214196, upload-time = "2025-01-02T07:32:43.59Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/9a/4114a9057db2f1462d5c8f8390ab7383925fe1ac012eaa42402ad65c2963/GitPython-3.1.44-py3-none-any.whl", hash = "sha256:9e0e10cda9bed1ee64bc9a6de50e7e38a9c9943241cd7f585f6df3ed28011110", size = 207599, upload-time = "2025-01-02T07:32:40.731Z" },
+]
+
+[[package]]
 name = "hatchling"
 version = "1.27.0"
 source = { registry = "https://pypi.org/simple" }
@@ -584,6 +608,15 @@ wheels = [
 ]
 
 [[package]]
+name = "smmap"
+version = "5.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/cd/a040c4b3119bbe532e5b0732286f805445375489fceaec1f48306068ee3b/smmap-5.0.2.tar.gz", hash = "sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5", size = 22329, upload-time = "2025-01-02T07:14:40.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl", hash = "sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e", size = 24303, upload-time = "2025-01-02T07:14:38.724Z" },
+]
+
+[[package]]
 name = "snowballstemmer"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -596,6 +629,7 @@ wheels = [
 name = "tmlt-nox-utils"
 source = { editable = "." }
 dependencies = [
+    { name = "gitpython" },
     { name = "nox" },
     { name = "uv-dynamic-versioning" },
 ]
@@ -619,6 +653,7 @@ pylint = [
 
 [package.metadata]
 requires-dist = [
+    { name = "gitpython", specifier = ">=3.1.44,<4" },
     { name = "nox", specifier = ">=2022.8.7" },
     { name = "uv-dynamic-versioning", specifier = ">=0.8.2,<0.9" },
 ]


### PR DESCRIPTION
Adds a new nox session, `make_release`, which takes a version number as an argument, updates the changelog, and pushes a release branch and tag for that version based on the current commit. All of the interactions with git are automated, but creating a PR to merge the release branch back to main requires a manual step for now, as AFAIK there's not a nice way to do it without also requiring GitHub credentials.

There are a few sanity checks in place to make sure this release process doesn't do anything bad:
- It will refuse to do anything if the repo is dirty or has untracked files, as these changes could be lost or unintentionally included in the release.
- It fetches from `origin` and checks that the release tag/branch being created doesn't already exist. There is technically a narrow window where two people could make the same release simultaneously, but GitHub should reject the second push anyway.
- It will only allow releases when the current branch is `main`; prerelease versions skip this check at present, as we could potentially want to make dev releases on side branches. If we in future want to enable making releases from stable branches (to patch old versions), that should be straightforward to exclude from this check as well.

We don't yet have a pipeline in place for automatically making a release when a tag is pushed, but this is a step towards mostly-automated releases.