### PR TITLE
Add a session for running the dependency matrix

### DIFF
--- a/nox-utils/src/tmlt/nox_utils/__init__.py
+++ b/nox-utils/src/tmlt/nox_utils/__init__.py
@@ -1,4 +1,9 @@
 """A central, largely package-agnostic collection of nox utilities."""
 
-from ._dependencies import install_group, show_installed, with_uv_env
+from ._dependencies import (
+    DependencyConfiguration,
+    install_group,
+    show_installed,
+    with_uv_env,
+)
 from ._session_manager import SessionManager

--- a/nox-utils/src/tmlt/nox_utils/_dependencies.py
+++ b/nox-utils/src/tmlt/nox_utils/_dependencies.py
@@ -1,19 +1,37 @@
 """Utilities for managing and inspecting dependencies in nox environments."""
 
 from functools import wraps
-from typing import Any, Callable
+from typing import Any, Callable, Dict, NamedTuple
 
 from nox import Session
+
+
+class DependencyConfiguration(NamedTuple):
+    """A named set of dependencies under which to run a session.
+
+    Args:
+        id: A name that can be used to identify this set of dependencies.
+        python: The python version to run under. E.g. '3.9'
+        packages: A dictionary containing any packages that should be pinned for
+            this configuration. Keys should be package names, and values should be
+            versions, in PEP440 format. E.g. `{"tmlt.core": ">=0.11.2,<0.12.0"}`.
+            Packages in this dictionary will be installed after the full set of
+            dependencies, and will override versions specified in the lockfile.
+    """
+
+    id: str
+    python: str
+    packages: Dict[str, str]
 
 
 def with_uv_env(f: Callable[[Session], Any]) -> Callable[[Session], Any]:
     """Configure given session to allow managing packages with uv."""
 
     @wraps(f)
-    def inner(sess: Session) -> Any:
+    def inner(sess: Session, *args, **kwargs) -> Any:
         if sess.virtualenv.is_sandboxed:
             sess.env["UV_PROJECT_ENVIRONMENT"] = sess.virtualenv.location
-        return f(sess)
+        return f(sess, *args, **kwargs)
 
     return inner
 
@@ -30,7 +48,7 @@ def install_group(
     def decorator(f: Callable[[Session], Any]) -> Callable[[Session], Any]:
         @wraps(f)
         @with_uv_env
-        def inner(sess: Session) -> Any:
+        def inner(sess: Session, *args, **kwargs) -> Any:
             if not sess.virtualenv.is_sandboxed:
                 sess.log(
                     "Not in a sandboxed environment, skipping package installation"
@@ -46,7 +64,7 @@ def install_group(
                 "--inexact",
                 external=True,
             )
-            return f(sess)
+            return f(sess, *args, **kwargs)
 
         return inner
 

--- a/nox-utils/src/tmlt/nox_utils/_environment.py
+++ b/nox-utils/src/tmlt/nox_utils/_environment.py
@@ -3,10 +3,14 @@
 import os
 import platform
 import subprocess
+import tempfile
+from functools import wraps
 from pathlib import Path
 
 import uv_dynamic_versioning.main as uvdv
 from nox import Session
+
+from .utils import get_session
 
 
 def in_ci() -> bool:
@@ -47,3 +51,28 @@ def num_cpus(sess: Session) -> int:
         sess.warn(f"Error getting CPU count, defaulting to 1: {e}")
         cores = 1
     return cores
+
+
+def with_clean_workdir(f):
+    """If in a sandboxed virtualenv, execute session from an empty tempdir.
+
+    This decorator works around an issue with the tests where they will try to
+    use the code (and thus the shared libraries) from the repository rather than
+    the wheel that should be used. By moving to a temporary directory before
+    running the tests, the repository is not in the Python load path, so the
+    problem is resolved.
+    """
+
+    @wraps(f)
+    def inner(*args, **kwargs):
+        print("with_clean_workdir")
+        print(args)
+        print(kwargs)
+        session = get_session(args)
+        if session.virtualenv.is_sandboxed:
+            with tempfile.TemporaryDirectory() as workdir, session.cd(workdir):
+                return f(*args, **kwargs)
+        else:
+            return f(*args, **kwargs)
+
+    return inner

--- a/nox-utils/src/tmlt/nox_utils/utils.py
+++ b/nox-utils/src/tmlt/nox_utils/utils.py
@@ -1,0 +1,18 @@
+"""Utility functions."""
+
+from nox import Session
+
+
+def get_session(args) -> Session:
+    """Given an argument list, get the Nox session from it.
+
+    This is a hack to allow using decorators interchangeably on normal functions
+    and class methods, as it effectively allows skipping the `self` argument to
+    class methods.
+    """
+    if len(args) > 0 and isinstance(args[0], Session):
+        return args[0]
+    elif len(args) > 1 and isinstance(args[1], Session):
+        return args[1]
+    else:
+        raise AssertionError("Couldn't find Nox session")


### PR DESCRIPTION
This is mostly based on the old dependency matrix session, but with a couple tweaks. I had to modify a number of our other decorators to pass arguments through, and added a NamedTuple for specifying entries in the matrix, to replace the old untyped nested dictionaries. I've tested it out with Analytics and it seems to work, though I'm still looking into problems I'm seeing with specific dependency combinations.